### PR TITLE
Add local-organizations.md with list of feminist orgs in SF

### DIFF
--- a/local-organizations.md
+++ b/local-organizations.md
@@ -1,0 +1,38 @@
+Local Organizations
+===================
+
+Below is a list of local feminist and/or women-in-tech groups, ordered by state and metropolitan area. You can use this list as a resource while performing outreach for your ClojureBridge event, or you can use it to avoid scheduling conflicts with other organizations.
+
+
+San Francisco Bay Area, CA
+---------------------------
+
+- [Double Union](https://doubleunion.org)
+	- Double Union is a non-profit hacker/maker space for women in San Francisco, with a physical location in the Mission. They are intersectional feminists, women-centered, and queer- and trans-inclusive.
+	- Double Union maintains a mailing list for all of its members. You can request that a ClojureBridge event be promoted via the mailing list by reaching out to Double Union's public email address, [doubleunionsf@gmail.com](mailto:doubleunionsf@gmail.com).
+
+- [Girl Develop It](http://www.girldevelopit.com)
+	- Girl Develop It is a non-profit organization that exists to provide affordable and accessible programs to women who want to learn web and software development through mentorship and hands-on instruction. They have 35 chapters across the United States (as of September 2014) and most frequently offer paid classes in front-end development, as well as free study groups to facilitate community learning.
+	- You can contact the organizers of Girl Develop It - San Francisco through their public email address, [sf@girldevelopit.com](mailto:sf@girldevelopit.com); reach out to one of the local leaders through their chapter's [website](http://www.girldevelopit.com/chapters/san-francisco); or view a list of upcoming events on the Girl Develop It - San Francisco [Meetup page](http://www.meetup.com/Girl-Develop-It-San-Francisco).
+
+- [Hackbright Academy](http://hackbrightacademy.com)
+	- Hackbright Academy is a for-profit organization that offers full-time, part-time, and weekend programming courses for women in San Francisco. They also host free events for women in tech, such as beginner-friendly hackathons and tech talks by women engineers.
+	- Hackbright maintains mailing lists for their alumni, as well as their current students. You can request for a ClojureBridge event to be promoted via the mailing lists by sending an email to [Angie Chang](mailto:a@hackbrightacademy.com), Hackbright's Director of Growth, or [Katherine Fellows](mailto:k@therinefello.ws), a Hackbright alumna who volunteers with ClojureBridge in San Francisco.
+
+- [Liberating Ourselves Locally](http://oaklandmakerspace.wordpress.com)
+	- Liberating Ourselves Locally is a people-of-color-led, gender-diverse, queer- and trans-inclusive hacker/maker space in East Oakland.
+	- You can contact Liberating Ourselves Locally via their public email address, [oaklandmakerspace@gmail.com](mailto:oaklandmakerspace@gmail.com).
+
+- [PyLadies](http://www.pyladies.com/)
+	- PyLadies is an international mentorship group with a focus on helping more women become active participants and leaders in the Python open-source community. Their mission is to promote, educate, and advance a diverse Python community through outreach, education, conferences, events, and social gatherings. They have 32 chapters across the world (as of September 2014) and provide a friendly support network for women and a bridge to the larger Python world.
+	- You can contact the organizers of PyLadies SF, as well as view a list of upcoming events, via their [Meetup page](http://www.meetup.com/PyLadiesSF).
+
+- [RailsBridge](http://www.railsbridge.org)
+	- RailsBridge is working to make tech more diverse and welcoming by teaching programming, connecting human beings, and listening to people's needs. They organize and teach free workshops on Rails, Ruby, and HTML & CSS in cities all over the world, targeted at groups of people that are underrepresented in tech. RailsBridge is a sister organization of ClojureBridge, and ClojureBridge closely follows their model.
+	- You can view a list of upcoming RailsBridge events in San Francisco at [BridgeTroll](http://bridgetroll.org).
+
+- [Women Who Code](https://www.womenwhocode.com)
+	- Women Who Code is a global non-profit dedicated to inspiring women to excel in technology careers. They provide an avenue into tech, empower women with skills needed for professional advancement, and provide environments where networking and mentorship are valued. They have 42 (as of September 2014) chapters across the world, which organize technical study groups, coding events, and tech talks by influential women in their respective regions.
+	- You can view a list of upcoming Women Who Code East Bay events, or contact the East Bay organizers, at their [Meetup page](http://www.meetup.com/Women-Who-Code-East-Bay).
+	- You can view a list of upcoming Women Who Code SF events, or contact the San Francisco organizers, at their page [Meetup page](http://www.meetup.com/Women-Who-Code-SF).
+	- You can request that your ClojureBridge event be posted in Women Who Code's worldwide online newsletter by emailing [womenwhocode@gmail.com](mailto:womenwhocode@gmail.com).


### PR DESCRIPTION
Added a file containing local feminist/women-in-tech organizations. This PR contains a limited selection of those within the San Francisco Bay Area.

Not entirely sure what the name of the file should be, or if we should turn this into a wiki like with the `community-docs` repo, but hey! Progress.
