### PR TITLE
Add initial CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# How to contribute
+
+Updates to the ClojureBridge organizing guide are welcome and encouraged. We would not have anything without the input from the volunteers who put on workshops.
+
+Also feel free to make forks of the organizing guide and not contribute back. Make different organizing guides, too. This guide is simply meant to provide suggestions for ClojureBridge workshop organizers.
+
+
+## Getting Started
+* Make sure you have a [GitHub account](https://github.com/signup/free)
+* Fork the repository on GitHub
+
+## Making Changes
+* Commit changes
+* (Add more git guidance?)
+
+## Submitting Changes
+* Push your committed changes to your local fork of the repository
+* Create a pull request 
+* Submit a pull request (PR) to the ClojureBridge/organizing repository
+* The ClojureBridge organizing guide team will review and discuss the pull requestin comments on the PR.
+* Two curriculum team members must give a thumbs up, then the PR will be accepted.
+
+
+# Organizing Guide Team
+* Wait, why does the organizing guide team get to say which PRs get accepted?? I'm glad you asked! If you contribute more than two patches, you, too, will become part of the organizing guide team. 
+* Organizing guide team members are given commit rights to the curriculum.
+* Commit rights are meant for approving PRs, not for making direct commits.
+
+
+# Workshop/Chapter organizing guide forks
+* Workshops or chapters that are using the main ClojureBridge organizing guide should fork the organizing guide in their chapter's github.
+* Give teachers commit rights to the chapter's fork of the organizing guide.
+* The submit pull requests to the main organizing guide, if you would like to contribute the changes back.


### PR DESCRIPTION
After this repo was switched from using the wiki to using the master branch, the ability for people to add information at will was lost. Accordingly, there should now be a `CONTRIBUTING` file to establish the protocol for merging commits, as well as the protocol for granting contributors write permissions.

This `CONTRIBUTING` file is pulled directly from [ClojureBridge/curriculum](http://github.com/clojurebridge/curriculum). Aside from substituting "organizing guide" for "curriculum" where appropriate, the only change I made was removing the reference to a mailing list--as we don't have one for the organizing guide.